### PR TITLE
perf: bounded parallel chunk ingestion (issue #5)

### DIFF
--- a/backend/app/api/graph.py
+++ b/backend/app/api/graph.py
@@ -348,7 +348,7 @@ def build_graph():
 
         max_workers = data.get('max_workers', Config.GRAPH_BUILD_WORKERS)
         try:
-            max_workers = max(1, int(max_workers))
+            max_workers = max(1, min(int(max_workers), Config.GRAPH_BUILD_WORKERS_MAX))
         except (TypeError, ValueError):
             max_workers = Config.GRAPH_BUILD_WORKERS
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -63,6 +63,14 @@ class Config:
     except (ValueError, AttributeError):
         GRAPH_BUILD_WORKERS = 2
 
+    # Hard server-side ceiling on client-supplied max_workers to prevent
+    # thread exhaustion.  Override via GRAPH_BUILD_WORKERS_MAX env var.
+    _graph_build_workers_max_str = os.environ.get('GRAPH_BUILD_WORKERS_MAX', '8')
+    try:
+        GRAPH_BUILD_WORKERS_MAX = max(1, int(_graph_build_workers_max_str.strip()))
+    except (ValueError, AttributeError):
+        GRAPH_BUILD_WORKERS_MAX = 8
+
     # OASIS simulation configuration
     OASIS_DEFAULT_MAX_ROUNDS = int(os.environ.get('OASIS_DEFAULT_MAX_ROUNDS', '10'))
     OASIS_SIMULATION_DATA_DIR = os.path.join(os.path.dirname(__file__), '../uploads/simulations')

--- a/backend/app/services/graph_builder.py
+++ b/backend/app/services/graph_builder.py
@@ -218,8 +218,8 @@ class GraphBuilderService:
 
         # Results indexed by original chunk position so ordering is preserved.
         results: Dict[int, str] = {}
-        completed_count = threading.Lock()
-        _done = [0]  # mutable counter shared across threads
+        _done_lock = threading.Lock()
+        _done_count = [0]  # chunks completed so far (for progress reporting)
         first_error: list = []  # [exception] — populated by first failing thread
 
         def _process_chunk(chunk_idx: int, chunk: str) -> tuple:
@@ -259,6 +259,15 @@ class GraphBuilderService:
                     try:
                         chunk_idx, episode_id = future.result()
                         results[chunk_idx] = episode_id
+                        with _done_lock:
+                            _done_count[0] += 1
+                            done_so_far = _done_count[0]
+                        if progress_callback:
+                            progress_callback(
+                                f"Chunk {done_so_far}/{total_chunks} complete "
+                                f"(batch {batch_num}/{total_batches})",
+                                done_so_far / total_chunks
+                            )
                     except Exception as e:
                         chunk_idx = futures[future]
                         logger.error(
@@ -267,6 +276,10 @@ class GraphBuilderService:
                         )
                         if not first_error:
                             first_error.append(e)
+                            # Cancel not-yet-started futures and stop waiting.
+                            for f in futures:
+                                f.cancel()
+                            break
 
             if first_error:
                 if progress_callback:

--- a/backend/app/storage/embedding_service.py
+++ b/backend/app/storage/embedding_service.py
@@ -7,6 +7,7 @@ Uses Ollama's /api/embed endpoint for vector generation (768 dimensions).
 
 import time
 import logging
+import threading
 from typing import List, Optional
 from functools import lru_cache
 
@@ -37,6 +38,7 @@ class EmbeddingService:
         # Using dict instead of lru_cache because lists aren't hashable
         self._cache: dict[str, List[float]] = {}
         self._cache_max_size = 2000
+        self._cache_lock = threading.Lock()  # guards all _cache reads/writes
 
     def embed(self, text: str) -> List[float]:
         """
@@ -57,8 +59,9 @@ class EmbeddingService:
         text = text.strip()
 
         # Check cache
-        if text in self._cache:
-            return self._cache[text]
+        with self._cache_lock:
+            if text in self._cache:
+                return self._cache[text]
 
         vectors = self._request_embeddings([text])
         vector = vectors[0]
@@ -91,8 +94,10 @@ class EmbeddingService:
         # Check cache first
         for i, text in enumerate(texts):
             text = text.strip() if text else ""
-            if text in self._cache:
-                results[i] = self._cache[text]
+            with self._cache_lock:
+                cached = self._cache.get(text)
+            if cached is not None:
+                results[i] = cached
             elif text:
                 uncached_indices.append(i)
                 uncached_texts.append(text)
@@ -183,12 +188,13 @@ class EmbeddingService:
 
     def _cache_put(self, text: str, vector: List[float]) -> None:
         """Add to cache, evicting oldest entries if full."""
-        if len(self._cache) >= self._cache_max_size:
-            # Remove ~10% of oldest entries
-            keys_to_remove = list(self._cache.keys())[:self._cache_max_size // 10]
-            for key in keys_to_remove:
-                del self._cache[key]
-        self._cache[text] = vector
+        with self._cache_lock:
+            if len(self._cache) >= self._cache_max_size:
+                # Remove ~10% of oldest entries
+                keys_to_remove = list(self._cache.keys())[:self._cache_max_size // 10]
+                for key in keys_to_remove:
+                    del self._cache[key]
+            self._cache[text] = vector
 
     def health_check(self) -> bool:
         """Check if Ollama embedding endpoint is reachable."""


### PR DESCRIPTION
## Summary

Resolves #5 — chunk ingestion was fully serial; each chunk waited for the previous NER + embedding + Neo4j write to complete before starting. Since all three operations are I/O-bound (Ollama HTTP calls and Neo4j bolt), running them concurrently within a batch gives a real wall-clock speedup proportional to `min(workers, batch_size)`.

---

## Changes

### `backend/app/config.py`
- New `GRAPH_BUILD_WORKERS` class attribute, driven by `GRAPH_BUILD_WORKERS` env var (default `2`)
- Parsed defensively (`try/except`, `.strip()`, minimum clamped to `1`)

### `backend/app/services/graph_builder.py`
- Import `ThreadPoolExecutor`, `as_completed` from `concurrent.futures`
- `add_text_batches()` gains an optional `max_workers` parameter (defaults to `Config.GRAPH_BUILD_WORKERS`)
- For each batch, chunks are submitted as `Future`s via a bounded `ThreadPoolExecutor`
- Results are accumulated in a `dict` keyed by original chunk index and reassembled in order after the pool drains — **episode UUID ordering is preserved**
- First exception from any worker is captured and re-raised after the executor context closes (avoids swallowing errors)
- Progress callbacks and logging remain thread-safe (only reads/appends to disjoint slots)

### `backend/app/api/graph.py`
- `max_workers` accepted in the `/build` request body (optional, defaults to `Config.GRAPH_BUILD_WORKERS`)
- Validated with `try/except`, clamped to `≥ 1`
- Passed through to `builder.add_text_batches()`
- Included in the task completion result dict
- Endpoint docstring updated

---

## Notes

- Default `GRAPH_BUILD_WORKERS=2` is conservative — Ollama handles one model call at a time so high concurrency just queues at the server. For remote/multi-GPU Ollama set this to 3–4.
- `batch_size` controls how many chunks are grouped before the next progress callback fires; `max_workers` controls parallelism within that group. Both can be tuned independently.
- Setting `GRAPH_BUILD_WORKERS=1` restores serial behaviour exactly.

---

## Testing checklist
- [ ] `python3 -m py_compile` on all three files — passes
- [ ] Graph build completes with default workers (2)
- [ ] `max_workers=1` produces the same result as before (serial)
- [ ] A worker exception propagates and fails the task correctly
- [ ] Episode UUIDs in result are in original chunk order